### PR TITLE
Histoire integration

### DIFF
--- a/histoire.config.ts
+++ b/histoire.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "histoire";
+import { HstVue } from "@histoire/plugin-vue";
+
+export default defineConfig({
+	plugins: [HstVue()],
+	storyIgnored: ["**/node_modules/**", "**/dist/**", "**/src-tauri/**"],
+	storyMatch: ["**/*.story.vue"],
+	setupFile: "/src/histoire.setup.ts",
+	tree: {
+		file: "path",
+	},
+	collectMaxThreads: 4,
+});

--- a/histoire.config.ts
+++ b/histoire.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 	storyMatch: ["**/*.story.vue"],
 	setupFile: "/src/histoire.setup.ts",
 	tree: {
-		file: "path",
+		file: "title",
 	},
 	collectMaxThreads: 4,
 	vite: {
@@ -31,5 +31,8 @@ export default defineConfig({
 				util: "util",
 			},
 		},
+	},
+	theme: {
+		title: "Open Knight",
 	},
 });

--- a/histoire.config.ts
+++ b/histoire.config.ts
@@ -10,4 +10,26 @@ export default defineConfig({
 		file: "path",
 	},
 	collectMaxThreads: 4,
+	vite: {
+		server: {
+			port: 6006,
+		},
+		define: {
+			// Define globals for Node.js compatibility
+			global: "globalThis",
+		},
+		optimizeDeps: {
+			// Force optimization of typia to fix exports issue
+			include: ["typia"],
+			force: true,
+		},
+		resolve: {
+			alias: {
+				// Enable template compilation for Vue
+				vue: "vue/dist/vue.esm-bundler.js",
+				// Provide browser-compatible alternatives for Node.js modules
+				util: "util",
+			},
+		},
+	},
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.28.0",
+				"@histoire/plugin-vue": "^1.0.0-alpha.2",
 				"@ryoppippi/unplugin-typia": "^2.1.4",
 				"@tailwindcss/postcss": "^4.1.7",
 				"@tauri-apps/cli": ">=2.0.0",
@@ -28,6 +29,7 @@
 				"daisyui": "^5.0.37",
 				"eslint": "^9.28.0",
 				"eslint-plugin-vue": "^10.2.0",
+				"histoire": "^1.0.0-alpha.2",
 				"postcss": "^8.4.49",
 				"prettier": "^3.5.3",
 				"prettier-plugin-vue": "^1.1.6",
@@ -37,6 +39,16 @@
 				"vite": "^6.3.5",
 				"vue-eslint-parser": "^10.1.3",
 				"vue-tsc": "^2.0.22"
+			}
+		},
+		"node_modules/@akryum/tinypool": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@akryum/tinypool/-/tinypool-0.3.1.tgz",
+			"integrity": "sha512-nznEC1ZA/m3hQDEnrGQ4c5gkaa9pcaVnw4LFJyzBAaR7E3nfiAPEHS3otnSafpZouVnoKeITl5D+2LsnwlnK8g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -64,6 +76,20 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
@@ -107,6 +133,208 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@codemirror/commands": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+			"integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.4.0",
+				"@codemirror/view": "^6.27.0",
+				"@lezer/common": "^1.1.0"
+			}
+		},
+		"node_modules/@codemirror/lang-json": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
+			"integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@lezer/json": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.11.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
+			"integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.1.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/lint": {
+			"version": "6.8.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+			"integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.35.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/theme-one-dark": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
+			"integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/highlight": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.37.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.37.1.tgz",
+			"integrity": "sha512-Qy4CAUwngy/VQkEz0XzMKVRcckQuqLYWKqVpDDDghBe5FSXSqfVrJn49nw3ePZHxRUz4nRmb05Lgi+9csWo4eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+			"integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+			"integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^5.0.2",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -720,6 +948,97 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@histoire/app": {
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@histoire/app/-/app-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-sGQ470fHS965pSFVtALY3sRkgBDQXzhnjshmR9gzIcqs3ZBCW4N1nyA6t7r3X++1cvgJ16ctWKQl/lFERwQLgA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@histoire/controls": "^1.0.0-alpha.2",
+				"@histoire/shared": "^1.0.0-alpha.2",
+				"@histoire/vendors": "^1.0.0-alpha.2",
+				"fuse.js": "^7.0.0",
+				"shiki": "^3.0.0"
+			}
+		},
+		"node_modules/@histoire/controls": {
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@histoire/controls/-/controls-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-05Oyb5PmYa7uYGss1mIwqH4qF1jqUs3iewuGAxVDOc5ERGwNQYm/pdiRWLSv8tYuCoYOn3N1wx3Gr5//F+cyTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/commands": "^6.7.1",
+				"@codemirror/lang-json": "^6.0.1",
+				"@codemirror/language": "^6.10.6",
+				"@codemirror/lint": "^6.8.4",
+				"@codemirror/state": "^6.4.1",
+				"@codemirror/theme-one-dark": "^6.1.2",
+				"@codemirror/view": "^6.35.0",
+				"@histoire/shared": "^1.0.0-alpha.2",
+				"@histoire/vendors": "^1.0.0-alpha.2"
+			}
+		},
+		"node_modules/@histoire/plugin-vue": {
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@histoire/plugin-vue/-/plugin-vue-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-MfXalw8Ld9wLVAmix311k8UoGm74xM988h7bFWgQipv+iu4LWjiXBD4hKThgrJh0siVCefAcOKdV91n71F1HHg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@histoire/controls": "^1.0.0-alpha.2",
+				"@histoire/shared": "^1.0.0-alpha.2",
+				"@histoire/vendors": "^1.0.0-alpha.2",
+				"change-case": "^5.4.4",
+				"globby": "^14.0.2",
+				"launch-editor": "^2.9.1",
+				"pathe": "^1.1.2"
+			},
+			"peerDependencies": {
+				"histoire": "^1.0.0-alpha.2",
+				"vue": "^3.2.47"
+			}
+		},
+		"node_modules/@histoire/plugin-vue/node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@histoire/shared": {
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@histoire/shared/-/shared-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-40suRsqX8sk9HFoN5u+ACYpIwp9Hzkgthf0NhXttUtUGU0dxTQU6JYC/mxJJhylTjbgQjY6UWF7kl+pwx32T1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@histoire/vendors": "^1.0.0-alpha.2",
+				"@types/fs-extra": "^11.0.4",
+				"@types/markdown-it": "^14.1.2",
+				"chokidar": "^4.0.1",
+				"pathe": "^1.1.2",
+				"picocolors": "^1.1.1"
+			},
+			"peerDependencies": {
+				"vite": "^6.0.1"
+			}
+		},
+		"node_modules/@histoire/shared/node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@histoire/vendors": {
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@histoire/vendors/-/vendors-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-5uef8/sfh7Pj2nHRX/Mp+u4t9fmZQIK2uyg7Ao/vKShzNdmZyiD4DNVRyXFhE3U67PrAbfcmy328gTC4YV/Seg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -850,6 +1169,52 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@lezer/common": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/json": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+			"integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.2.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -899,6 +1264,13 @@
 			"peerDependencies": {
 				"vue": ">=3.2.39"
 			}
+		},
+		"node_modules/@polka/url": {
+			"version": "1.0.0-next.29",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.1.4",
@@ -1270,6 +1642,93 @@
 			"resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-3.2.3.tgz",
 			"integrity": "sha512-CQVa92i3hvfZftd6mULs13/WRib5a5/5qfEH/L6e5gjSSHIXrKMmwVPawi447F/bQiEd4EPE+dPmGU3lvEsVqw==",
 			"license": "MIT"
+		},
+		"node_modules/@shikijs/core": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.6.0.tgz",
+			"integrity": "sha512-9By7Xb3olEX0o6UeJyPLI1PE1scC4d3wcVepvtv2xbuN9/IThYN4Wcwh24rcFeASzPam11MCq8yQpwwzCgSBRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.6.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.6.0.tgz",
+			"integrity": "sha512-7YnLhZG/TU05IHMG14QaLvTW/9WiK8SEYafceccHUSXs2Qr5vJibUwsDfXDLmRi0zHdzsxrGKpSX6hnqe0k8nA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.6.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.3"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.6.0.tgz",
+			"integrity": "sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.6.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.6.0.tgz",
+			"integrity": "sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.6.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.6.0.tgz",
+			"integrity": "sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.6.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.6.0.tgz",
+			"integrity": "sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.1.7",
@@ -1777,10 +2236,93 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/fs-extra": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+			"integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsonfile": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/jsonfile": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+			"integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+			"integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.8.0"
+			}
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2018,6 +2560,13 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/@vitejs/plugin-vue": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -2212,6 +2761,16 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2277,6 +2836,13 @@
 			"resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
 			"integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2301,6 +2867,16 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/birpc": {
+			"version": "0.2.19",
+			"resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
+			"integrity": "sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
 		},
 		"node_modules/bl": {
 			"version": "4.1.0",
@@ -2364,6 +2940,30 @@
 				"ieee754": "^1.1.13"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2372,6 +2972,17 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/chalk": {
@@ -2389,10 +3000,55 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/change-case": {
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+			"integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
 		},
 		"node_modules/chownr": {
 			"version": "3.0.0",
@@ -2458,6 +3114,30 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/commander": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -2507,6 +3187,39 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/connect": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"finalhandler": "1.1.2",
+				"parseurl": "~1.3.3",
+				"utils-merge": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/connect/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/connect/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/consola": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -2521,6 +3234,13 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -2550,6 +3270,27 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/cssstyle": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.4.0.tgz",
+			"integrity": "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/cssstyle/node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2563,6 +3304,20 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/saadeghi/daisyui?sponsor=1"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/de-indent": {
@@ -2589,6 +3344,13 @@
 				}
 			}
 		},
+		"node_modules/decimal.js": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+			"integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2613,6 +3375,26 @@
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
 			"dev": true
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2622,6 +3404,27 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/diacritics": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+			"integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/diff-match-patch-es": {
 			"version": "1.0.1",
@@ -2641,10 +3444,42 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"node_modules/encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.1",
@@ -2669,6 +3504,55 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/esbuild": {
@@ -2711,6 +3595,13 @@
 				"@esbuild/win32-ia32": "0.25.4",
 				"@esbuild/win32-x64": "0.25.4"
 			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
@@ -3082,6 +3973,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -3196,6 +4100,42 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/finalhandler": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/finalhandler/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/finalhandler/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/find-cache-dir": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-5.0.0.tgz",
@@ -3249,6 +4189,38 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/form-data": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3261,6 +4233,65 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/fuse.js": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+			"integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -3289,6 +4320,40 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globby": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.3",
+				"ignore": "^7.0.3",
+				"path-type": "^6.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3302,6 +4367,46 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/gray-matter": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+			"integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-yaml": "^3.13.1",
+				"kind-of": "^6.0.2",
+				"section-matter": "^1.0.0",
+				"strip-bom-string": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.0"
+			}
+		},
+		"node_modules/gray-matter/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/gray-matter/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -3319,6 +4424,86 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -3326,6 +4511,109 @@
 			"dev": true,
 			"bin": {
 				"he": "bin/he"
+			}
+		},
+		"node_modules/histoire": {
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/histoire/-/histoire-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-W0u5svVoFq6cCoO7CwRMpqVecp260riENpFJEb2pLyurDBFNU4vVyskTnxm5MGwMf4+sjjWp5WXPBvJ22Mxglg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@akryum/tinypool": "^0.3.1",
+				"@histoire/app": "^1.0.0-alpha.2",
+				"@histoire/controls": "^1.0.0-alpha.2",
+				"@histoire/shared": "^1.0.0-alpha.2",
+				"@histoire/vendors": "^1.0.0-alpha.2",
+				"@types/markdown-it": "^14.1.2",
+				"birpc": "^0.2.19",
+				"change-case": "^5.4.4",
+				"chokidar": "^4.0.1",
+				"connect": "^3.7.0",
+				"defu": "^6.1.4",
+				"diacritics": "^1.3.0",
+				"fs-extra": "^11.2.0",
+				"globby": "^14.0.2",
+				"gray-matter": "^4.0.3",
+				"jiti": "^2.4.1",
+				"jsdom": "^25.0.1",
+				"markdown-it": "^14.1.0",
+				"markdown-it-anchor": "^9.2.0",
+				"markdown-it-attrs": "^4.3.0",
+				"markdown-it-emoji": "^3.0.0",
+				"micromatch": "^4.0.8",
+				"mrmime": "^2.0.0",
+				"pathe": "^1.1.2",
+				"picocolors": "^1.1.1",
+				"sade": "^1.8.1",
+				"shiki": "^3.0.0",
+				"sirv": "^3.0.0",
+				"vite-node": "0.34.7"
+			},
+			"bin": {
+				"histoire": "bin.mjs"
+			},
+			"peerDependencies": {
+				"vite": "^6.0.1"
+			}
+		},
+		"node_modules/histoire/node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -3425,6 +4713,16 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3474,6 +4772,13 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3515,6 +4820,57 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsdom": {
+			"version": "25.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+			"integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssstyle": "^4.1.0",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.4.3",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.5",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.12",
+				"parse5": "^7.1.2",
+				"rrweb-cssom": "^0.7.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.0.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^2.11.2"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3536,6 +4892,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3544,6 +4913,27 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/launch-editor": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
+			"integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picocolors": "^1.0.0",
+				"shell-quote": "^1.8.1"
 			}
 		},
 		"node_modules/levn": {
@@ -3799,6 +5189,16 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -3841,6 +5241,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -3849,6 +5256,94 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
+		},
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it-anchor": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
+			"integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
+			"dev": true,
+			"license": "Unlicense",
+			"peerDependencies": {
+				"@types/markdown-it": "*",
+				"markdown-it": "*"
+			}
+		},
+		"node_modules/markdown-it-attrs": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.3.1.tgz",
+			"integrity": "sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"markdown-it": ">= 9.0.0"
+			}
+		},
+		"node_modules/markdown-it-emoji": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-3.0.0.tgz",
+			"integrity": "sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+			"integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -3859,6 +5354,100 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -3872,6 +5461,29 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -3936,6 +5548,58 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/mlly": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"pathe": "^2.0.1",
+				"pkg-types": "^1.3.0",
+				"ufo": "^1.5.4"
+			}
+		},
+		"node_modules/mlly/node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mlly/node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/mrmime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3992,6 +5656,26 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
+		"node_modules/nwsapi": {
+			"version": "2.2.20",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+			"integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -4004,6 +5688,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+			"integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
+			"integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"oniguruma-parser": "^0.12.1",
+				"regex": "^6.0.1",
+				"regex-recursion": "^6.0.2"
 			}
 		},
 		"node_modules/optionator": {
@@ -4102,6 +5805,42 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/path-browserify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -4125,6 +5864,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/path-type": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/pathe": {
@@ -4323,10 +6075,31 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
+		"node_modules/property-information": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+			"integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4378,6 +6151,47 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+			"integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/repeat-string": {
 			"version": "1.6.1",
@@ -4468,6 +6282,13 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+			"integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -4508,6 +6329,19 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"node_modules/sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mri": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4531,6 +6365,33 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
+		"node_modules/section-matter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+			"integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"kind-of": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/semver": {
 			"version": "7.6.3",
@@ -4567,10 +6428,68 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shell-quote": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/shiki": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.6.0.tgz",
+			"integrity": "sha512-tKn/Y0MGBTffQoklaATXmTqDU02zx8NYBGQ+F6gy87/YjKbizcLd+Cybh/0ZtOBX9r1NEnAy/GTRDKtOsc1L9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "3.6.0",
+				"@shikijs/engine-javascript": "3.6.0",
+				"@shikijs/engine-oniguruma": "3.6.0",
+				"@shikijs/langs": "3.6.0",
+				"@shikijs/themes": "3.6.0",
+				"@shikijs/types": "3.6.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+		},
+		"node_modules/sirv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+			"integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@polka/url": "^1.0.0-next.24",
+				"mrmime": "^2.0.0",
+				"totalist": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
@@ -4578,6 +6497,34 @@
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -4601,6 +6548,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4610,6 +6572,16 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+			"integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -4625,6 +6597,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/style-mod": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4635,6 +6614,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
 			"version": "4.1.7",
@@ -4721,6 +6707,26 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -4751,6 +6757,53 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/totalist": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -4851,6 +6904,133 @@
 				"typescript": ">=4.8.0 <5.9.0"
 			}
 		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ufo": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+			"integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+			"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/unplugin": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.2.2.tgz",
@@ -4879,6 +7059,46 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
+		"node_modules/utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+			"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
 		},
 		"node_modules/vite": {
 			"version": "6.3.5",
@@ -4951,6 +7171,527 @@
 					"optional": true
 				},
 				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "0.34.7",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.7.tgz",
+			"integrity": "sha512-0Yzb96QzHmqIKIs/x2q/sqG750V/EF6yDkS2p1WjJc1W2bgRSuQjf5vB9HY8h2nVb5j4pO5paS5Npcv3s69YUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.3.4",
+				"mlly": "^1.4.0",
+				"pathe": "^1.1.1",
+				"picocolors": "^1.0.0",
+				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": ">=v14.18.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+			"integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/android-arm": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+			"integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+			"integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/android-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+			"integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+			"integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+			"integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+			"integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+			"integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+			"integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+			"integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+			"integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+			"integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+			"integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+			"integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+			"integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+			"integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+			"integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+			"integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+			"integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+			"integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+			"integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+			"integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+			"integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/esbuild": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.21.5",
+				"@esbuild/android-arm": "0.21.5",
+				"@esbuild/android-arm64": "0.21.5",
+				"@esbuild/android-x64": "0.21.5",
+				"@esbuild/darwin-arm64": "0.21.5",
+				"@esbuild/darwin-x64": "0.21.5",
+				"@esbuild/freebsd-arm64": "0.21.5",
+				"@esbuild/freebsd-x64": "0.21.5",
+				"@esbuild/linux-arm": "0.21.5",
+				"@esbuild/linux-arm64": "0.21.5",
+				"@esbuild/linux-ia32": "0.21.5",
+				"@esbuild/linux-loong64": "0.21.5",
+				"@esbuild/linux-mips64el": "0.21.5",
+				"@esbuild/linux-ppc64": "0.21.5",
+				"@esbuild/linux-riscv64": "0.21.5",
+				"@esbuild/linux-s390x": "0.21.5",
+				"@esbuild/linux-x64": "0.21.5",
+				"@esbuild/netbsd-x64": "0.21.5",
+				"@esbuild/openbsd-x64": "0.21.5",
+				"@esbuild/sunos-x64": "0.21.5",
+				"@esbuild/win32-arm64": "0.21.5",
+				"@esbuild/win32-ia32": "0.21.5",
+				"@esbuild/win32-x64": "0.21.5"
+			}
+		},
+		"node_modules/vite-node/node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vite-node/node_modules/vite": {
+			"version": "5.4.19",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+			"integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.21.3",
+				"postcss": "^8.4.43",
+				"rollup": "^4.20.0"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"less": "*",
+				"lightningcss": "^1.21.0",
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
 					"optional": true
 				}
 			}
@@ -5064,6 +7805,36 @@
 				"typescript": ">=5.0.0"
 			}
 		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -5072,12 +7843,72 @@
 				"defaults": "^1.0.3"
 			}
 		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/webpack-virtual-modules": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
 			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-encoding/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -5118,6 +7949,28 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ws": {
+			"version": "8.18.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/xml-name-validator": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -5127,6 +7980,13 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yallist": {
 			"version": "5.0.0",
@@ -5163,6 +8023,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@typescript-eslint/eslint-plugin": "^8.33.1",
 				"@typescript-eslint/parser": "^8.33.1",
 				"@vitejs/plugin-vue": "^5.2.4",
+				"buffer": "^6.0.3",
 				"daisyui": "^5.0.37",
 				"eslint": "^9.28.0",
 				"eslint-plugin-vue": "^10.2.0",
@@ -36,6 +37,7 @@
 				"tailwindcss": "^4.1.7",
 				"typescript": "^5.6.3",
 				"typescript-eslint": "^8.33.1",
+				"util": "^0.12.5",
 				"vite": "^6.3.5",
 				"vue-eslint-parser": "^10.1.3",
 				"vue-tsc": "^2.0.22"
@@ -2843,6 +2845,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2888,6 +2906,30 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/bl/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2918,9 +2960,10 @@
 			}
 		},
 		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2935,9 +2978,10 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/cac": {
@@ -2948,6 +2992,25 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -2962,6 +3025,23 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
@@ -3367,6 +3447,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/defu": {
@@ -4189,6 +4287,22 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
@@ -4422,6 +4536,19 @@
 			"integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -4713,6 +4840,36 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/is-arguments": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4739,6 +4896,25 @@
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-generator-function": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.0",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-glob": {
@@ -4778,6 +4954,41 @@
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/is-regex": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
@@ -5984,6 +6195,16 @@
 				"pathe": "^2.0.3"
 			}
 		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -6361,6 +6582,24 @@
 				}
 			]
 		},
+		"node_modules/safe-regex-test": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6403,6 +6642,24 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -7053,6 +7310,20 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -7924,6 +8195,28 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"clean": "rm -rf src-tauri/target dist",
-		"clean:db": "rm -f src-tauri/chess.db"
+		"clean:db": "rm -f src-tauri/chess.db",
+		"story:dev": "histoire dev",
+		"story:build": "histoire build",
+		"story:preview": "histoire preview"
 	},
 	"dependencies": {
 		"@phosphor-icons/vue": "^2.2.1",
@@ -35,6 +38,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",
+		"@histoire/plugin-vue": "^1.0.0-alpha.2",
 		"@ryoppippi/unplugin-typia": "^2.1.4",
 		"@tailwindcss/postcss": "^4.1.7",
 		"@tauri-apps/cli": ">=2.0.0",
@@ -44,6 +48,7 @@
 		"daisyui": "^5.0.37",
 		"eslint": "^9.28.0",
 		"eslint-plugin-vue": "^10.2.0",
+		"histoire": "^1.0.0-alpha.2",
 		"postcss": "^8.4.49",
 		"prettier": "^3.5.3",
 		"prettier-plugin-vue": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@typescript-eslint/eslint-plugin": "^8.33.1",
 		"@typescript-eslint/parser": "^8.33.1",
 		"@vitejs/plugin-vue": "^5.2.4",
+		"buffer": "^6.0.3",
 		"daisyui": "^5.0.37",
 		"eslint": "^9.28.0",
 		"eslint-plugin-vue": "^10.2.0",
@@ -55,6 +56,7 @@
 		"tailwindcss": "^4.1.7",
 		"typescript": "^5.6.3",
 		"typescript-eslint": "^8.33.1",
+		"util": "^0.12.5",
 		"vite": "^6.3.5",
 		"vue-eslint-parser": "^10.1.3",
 		"vue-tsc": "^2.0.22"

--- a/src/App.vue
+++ b/src/App.vue
@@ -108,11 +108,7 @@
 									:position="gamesStore.getCurrentPosition(activeBoardId)"
 									:move="currentMove?.game_move ?? null"
 									:valid-moves="validMoves"
-									:has-next-move="hasNextMove"
-									:has-previous-move="hasPreviousMove"
 									@make-move="handleMakeMove"
-									@previous-move="gamesStore.previousMove(activeBoardId)"
-									@next-move="gamesStore.nextMove(activeBoardId)"
 									@rotate-board="uiStore.setWhiteOnSide()"
 									@resize-board="uiStore.updateBoardSquareSize($event)"
 								/>
@@ -297,10 +293,6 @@ const currentPosition = computed(() =>
 const currentMove = computed(() =>
 	gamesStore.getCurrentMove(activeBoardId.value),
 );
-const hasNextMove = computed(
-	() => (currentMove.value?.children_ids.length ?? 0) > 0,
-);
-const hasPreviousMove = computed(() => !!currentMove.value?.parent_id);
 
 const validMoves = ref<LegalMove[] | null>(null);
 watch(currentPosition, async (newPosition) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,11 +37,19 @@
 						title="Game Library"
 						:icon="PhBooks"
 						:collapsed="isLeftPanelSectionCollapsed('gameLibrary')"
-						@toggle="toggleLeftPanelSection('gameLibrary', $event)"
+						@toggle="toggleLeftPanelSection('gameLibrary')"
 						:min-height="400"
 					>
 
-						<GameLibrary />
+						<GameLibrary
+							:games="explorerGames"
+							:is-loading="isLoading"
+							:error="error"
+							@open-game="handleOpenGame"
+							@delete-game="handleDeleteGame"
+							@update-game-property="handleUpdateGameProperty"
+							@refresh-games="refreshGamesClick"
+						/>
 
 					</StackedSection>
 
@@ -75,24 +83,39 @@
 
 						<div class="flex flex-row">
 
-							<!-- TODO: We need to invalidate the evaluation when the board changes
-							 currently it re-uses the evaluation from the previous position
-							  -->
-
 							<EvaluationBar
 								class="min-h-full max-w-10"
-								:evaluation="engineAnalysisStore.boardEvaluation"
-								:evaluation-side="
-									globalStore.gamesStore.getCurrentTurn(activeBoardId) ??
-									'white'
+								:evaluation="
+									analysis?.score ?? { value: 0, type: 'centipawns' }
 								"
-								:orientation="uiStore.whiteOnSide === 'top' ? 'black' : 'white'"
+								:evaluation-side="
+									gamesStore.getCurrentTurn(activeBoardId) ?? 'white'
+								"
+								:orientation="
+									uiStore.whiteOnSide === 'bottom' ? 'white' : 'black'
+								"
 								direction="vertical"
 							/>
 
 							<div class="flex flex-col">
 
-								<ChessBoard :board-id="activeBoardId" />
+								<ChessBoard
+									:board-id="activeBoardId"
+									:theme="uiStore.boardTheme"
+									:show-coordinates="uiStore.showCoordinates"
+									:show-legal-moves="uiStore.showLegalMoves"
+									:is-flipped="uiStore.whiteOnSide === 'top'"
+									:position="gamesStore.getCurrentPosition(activeBoardId)"
+									:move="currentMove?.game_move ?? null"
+									:valid-moves="validMoves"
+									:has-next-move="hasNextMove"
+									:has-previous-move="hasPreviousMove"
+									@make-move="handleMakeMove"
+									@previous-move="gamesStore.previousMove(activeBoardId)"
+									@next-move="gamesStore.nextMove(activeBoardId)"
+									@rotate-board="uiStore.setWhiteOnSide()"
+									@resize-board="uiStore.updateBoardSquareSize($event)"
+								/>
 
 							</div>
 
@@ -130,13 +153,13 @@
 					<template #moveTree>
 
 						<MoveDisplay
-							v-if="globalStore?.activeGame !== null"
-							:move-tree="globalStore.activeGame.move_tree"
+							v-if="boardState?.game"
+							:move-tree="boardState.game.move_tree"
 							@select-move="handleMoveSelect"
-							@navigate-start="navigateToStart"
-							@navigate-end="navigateToEnd"
-							@navigate-previous="navigateToPrevious"
-							@navigate-next="navigateToNext"
+							@navigate-start="gamesStore.navigateToStart(activeBoardId)"
+							@navigate-end="gamesStore.navigateToEnd(activeBoardId)"
+							@navigate-previous="gamesStore.previousMove(activeBoardId)"
+							@navigate-next="gamesStore.nextMove(activeBoardId)"
 						/>
 
 						<div
@@ -152,7 +175,33 @@
 
 					<template #engine>
 
-						<EngineAnalysisPanel :board-id="activeBoardId" />
+						<EngineAnalysisPanel
+							:board-id="activeBoardId"
+							:current-position-fen="
+								gamesStore.getCurrentPosition(activeBoardId)?.fen ?? null
+							"
+							:current-game-id="boardState?.game.id ?? null"
+							:engine-settings="
+								Object.entries(
+									engineAnalysisStore.getEngineSettings(selectedEngine),
+								)
+							"
+							:latest-analysis-result="analysis ?? null"
+							:latest-best-move="bestMove ?? null"
+							:is-analyzing="engineAnalysisStore.isAnalyzing(selectedEngine)"
+							:is-game-analysis-in-progress="
+								engineAnalysisStore.gameAnalysisInProgress
+							"
+							:available-engines="availableEngines"
+							:selected-engine="selectedEngine"
+							@update:selected-engine="selectedEngine = $event"
+							@load-engine="handleLoadEngine"
+							@unload-engine="engineAnalysisStore.unloadEngine($event)"
+							@start-analysis="handleStartAnalysis"
+							@stop-analysis="engineAnalysisStore.stopAnalysis(selectedEngine)"
+							@start-game-analysis="handleStartGameAnalysis"
+							@update:engine-settings="handleUpdateEngineSettings"
+						/>
 
 					</template>
 
@@ -167,7 +216,7 @@
 	<!-- Modals -->
 
 	<SettingsModal
-		:is-open="settingsModalOpen"
+		:is-open="uiStore.settingsModalOpen"
 		@close="uiStore.updateSettingsModalOpen(false)"
 	/>
 
@@ -182,7 +231,7 @@
 
 <script setup lang="ts">
 import { PhBooks, PhEngine, PhTree } from "@phosphor-icons/vue";
-import { computed, onMounted, provide, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import ChessBoard from "./components/ChessBoard/ChessBoard.vue";
 import EngineAnalysisPanel from "./components/EngineAnalysis/EngineAnalysisPanel.vue";
 import EvaluationBar from "./components/EvaluationBar/EvaluationBar.vue";
@@ -195,146 +244,218 @@ import MoveDisplay from "./components/MoveDisplay/MoveDisplay.vue";
 import Navbar from "./components/Navbar/Navbar.vue";
 import SettingsModal from "./components/Settings/SettingsModal.vue";
 import Toasts from "./components/Toast/Toasts.vue";
-import { useGlobalStore } from "./stores";
+import { API } from "./shared/api";
+import type { EngineSettings, ExplorerGame } from "./shared/types";
+import type { LegalMove } from "./shared/bindings";
+import { useEngineAnalysisStore } from "./stores/engineAnalysis";
+import { useGamesStore } from "./stores/games";
+import { useUIStore } from "./stores/ui";
+import { resetDatabase } from "./services/ImportExportService";
+
+const gamesStore = useGamesStore();
+const engineAnalysisStore = useEngineAnalysisStore();
+const uiStore = useUIStore();
 
 const importModalOpen = ref(false);
-const globalStore = useGlobalStore();
-const engineAnalysisStore = globalStore.engineAnalysisStore;
-const uiStore = globalStore.uiStore;
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+async function execute<T>(promise: Promise<T>): Promise<T | undefined> {
+	isLoading.value = true;
+	error.value = null;
+	try {
+		return await promise;
+	} catch (e: any) {
+		error.value = e.message;
+	} finally {
+		isLoading.value = false;
+	}
+}
 
-// Layout state
-const layout = computed(() => uiStore.layout);
-const settingsModalOpen = computed(() => uiStore.getSettingsModalOpen);
-const displayLeftPanel = computed(() => uiStore.getLeftPanelOpen);
-const displayRightPanel = computed(() => uiStore.getRightPanelOpen);
+const explorerGames = ref<ExplorerGame[]>([]);
+async function refreshGamesClick() {
+	const result = await execute(API.games.list());
+	if (result) explorerGames.value = result;
+}
 
-// Multi-board support
-const activeBoardIds = computed(() => uiStore.getActiveBoardIds);
-const activeBoardId = computed(() => uiStore.getActiveBoardId);
-
-// Right panel tabs configuration
-const rightPanelSections = computed(() => [
-	{
-		id: "moveTree",
-		title: "Move Tree",
-		icon: PhTree,
-	},
-	{
-		id: "engine",
-		title: "Engine",
-		icon: PhEngine,
-	},
-]);
-
-const rightPanelActiveTab = computed(() => {
-	const panelState = uiStore.getStackedPanelState("rightPanel");
-	return panelState.activeTab || "moveTree";
+onMounted(async () => {
+	await refreshGamesClick();
+	engineAnalysisStore.initAnalysisService();
 });
 
-// Layout resize handlers
-const updateLeftPanelWidth = (width: number) => {
-	uiStore.updateLayoutDimension("leftPanelWidth", width);
-};
+// =================================================================================================
+// Board State
+// =================================================================================================
 
-const updateRightPanelWidth = (width: number) => {
-	uiStore.updateLayoutDimension("rightPanelWidth", width);
-};
+const activeBoardId = computed(() => uiStore.activeBoardId);
+const activeBoardIds = computed(() => uiStore.activeBoardIds);
+const boardState = computed(() =>
+	gamesStore.getBoardState(activeBoardId.value),
+);
+const currentPosition = computed(() =>
+	gamesStore.getCurrentPosition(activeBoardId.value),
+);
+const currentMove = computed(() =>
+	gamesStore.getCurrentMove(activeBoardId.value),
+);
+const hasNextMove = computed(
+	() => (currentMove.value?.children_ids.length ?? 0) > 0,
+);
+const hasPreviousMove = computed(() => !!currentMove.value?.parent_id);
 
-// Board management
-const setActiveBoardId = (boardId: number) => {
-	uiStore.setActiveBoardId(boardId);
-};
+const validMoves = ref<LegalMove[] | null>(null);
+watch(currentPosition, async (newPosition) => {
+	if (!newPosition) {
+		validMoves.value = null;
+		return;
+	}
+	validMoves.value = await gamesStore.getValidMoves(activeBoardId.value);
+});
 
-const closeBoardTab = (boardId: number) => {
-	uiStore.closeBoardTab(boardId);
-	globalStore.gamesStore.closeGame(boardId);
-};
+function handleMakeMove(move: LegalMove) {
+	gamesStore.makeMove(activeBoardId.value, move.uci);
+}
 
-const createNewBoard = () => {
+function handleMoveSelect(moveId: number) {
+	gamesStore.jumpToMove(activeBoardId.value, moveId);
+}
+
+function newGameClick() {
+	gamesStore.newGame(activeBoardId.value);
+}
+
+async function handleOpenGame(payload: { gameId: number; newBoard: boolean }) {
+	await gamesStore.openGame(payload.gameId, activeBoardId.value);
+}
+
+async function handleDeleteGame(gameId: number) {
+	const deleted = await gamesStore.deleteGame(gameId);
+	if (deleted) await refreshGamesClick();
+}
+
+async function handleUpdateGameProperty(payload: {
+	gameId: number;
+	field: string;
+	value: any;
+}) {
+	await API.games.update(payload.gameId, payload.field, payload.value);
+	await refreshGamesClick();
+}
+
+async function resetDatabaseClick() {
+	await resetDatabase();
+	await refreshGamesClick();
+	await gamesStore.newGame(activeBoardId.value);
+}
+
+// =================================================================================================
+// Board Tabs
+// =================================================================================================
+
+function createNewBoard() {
 	uiStore.createNewBoard();
-};
+}
 
-const renameBoard = (boardId: number, newName: string) => {
-	uiStore.renameBoard(boardId, newName);
-};
+function setActiveBoardId(boardId: number) {
+	uiStore.setActiveBoardId(boardId);
+}
 
-const saveBoard = (boardId: number) => {
-	globalStore.gamesStore.saveGame(boardId);
-	uiStore.updateBoardMetadata(boardId, { hasUnsavedChanges: false });
-};
+function closeBoardTab(boardId: number) {
+	gamesStore.closeGame(boardId);
+	uiStore.closeBoardTab(boardId);
+}
 
-// Existing handlers
-const refreshGamesClick = async () => {
-	await globalStore.fetchExplorerGames();
-};
+function renameBoard(boardId: number, name: string) {
+	uiStore.renameBoard(boardId, name);
+}
 
-const resetDatabaseClick = async () => {
-	await globalStore.resetDatabase();
-};
+async function saveBoard(boardId: number) {
+	await gamesStore.saveGame(boardId);
+}
 
-// Stacked panel handlers
-const handleLeftPanelSectionToggle = (
-	sectionId: string,
-	_collapsed: boolean,
-) => {
+// =================================================================================================
+// Panel Layout
+// =================================================================================================
+
+const layout = computed(() => uiStore.layout);
+const displayLeftPanel = computed(() => uiStore.leftPanelOpen);
+const displayRightPanel = computed(() => uiStore.rightPanelOpen);
+const isLeftPanelSectionCollapsed = (section: string) =>
+	uiStore
+		.getStackedPanelState("leftPanel")
+		?.collapsedSections?.includes(section) ?? false;
+const rightPanelActiveTab = computed(
+	() => uiStore.getStackedPanelState("rightPanel")?.activeTab,
+);
+
+const rightPanelSections = [
+	{ id: "moveTree", title: "Move Tree", icon: PhTree },
+	{ id: "engine", title: "Engine", icon: PhEngine },
+];
+
+function updateLeftPanelWidth(width: number) {
+	uiStore.updateLayoutDimension("leftPanelWidth", width);
+}
+
+function updateRightPanelWidth(width: number) {
+	uiStore.updateLayoutDimension("rightPanelWidth", width);
+}
+
+function toggleLeftPanelSection(sectionId: string) {
 	uiStore.toggleStackedPanelSection("leftPanel", sectionId);
-};
+}
 
-const toggleLeftPanelSection = (sectionId: string, _collapsed: boolean) => {
-	uiStore.toggleStackedPanelSection("leftPanel", sectionId);
-};
+function handleLeftPanelSectionToggle(sectionId: string, collapsed: boolean) {
+	if (
+		(isLeftPanelSectionCollapsed(sectionId) && !collapsed) ||
+		(!isLeftPanelSectionCollapsed(sectionId) && collapsed)
+	) {
+		uiStore.toggleStackedPanelSection("leftPanel", sectionId);
+	}
+}
 
-const isLeftPanelSectionCollapsed = (sectionId: string) => {
-	const panelState = uiStore.getStackedPanelState("leftPanel");
-	return panelState.collapsedSections?.includes(sectionId) ?? false;
-};
-
-const handleRightPanelTabChange = (tabId: string) => {
+function handleRightPanelTabChange(tabId: string) {
 	uiStore.setStackedPanelActiveTab("rightPanel", tabId);
-};
+}
 
-onMounted(() => {
-	globalStore.fetchExplorerGames();
+// =================================================================================================
+// Engine Analysis
+// =================================================================================================
 
-	// Load saved layout preferences
-	uiStore.loadLayoutPreferences();
-});
+const availableEngines = computed(() =>
+	Array.from(engineAnalysisStore.engines.keys()),
+);
+const selectedEngine = ref("Stockfish NNUE");
+const analysis = computed(() =>
+	engineAnalysisStore.getLatestAnalysisUpdate(selectedEngine.value),
+);
+const bestMove = computed(() =>
+	engineAnalysisStore.getLatestBestMove(selectedEngine.value),
+);
 
-// Setup default styles for Phosphor icons
-provide("color", "currentColor");
-provide("size", 30);
-provide("weight", "bold");
-provide("mirrored", false);
+function handleUpdateEngineSettings(payload: {
+	engine: string;
+	settings: EngineSettings;
+}) {
+	engineAnalysisStore.updateEngineSettings(payload.engine, payload.settings);
+}
 
-// Navigation event handlers for MoveTree
-const handleMoveSelect = async (moveId: number) => {
-	await globalStore.gamesStore.jumpToMove(activeBoardId.value, moveId);
-};
+async function handleLoadEngine(payload: { name: string; path: string }) {
+	await engineAnalysisStore.loadEngine(payload.name, payload.path);
+}
 
-const navigateToStart = async () => {
-	await globalStore.gamesStore.navigateToStart(activeBoardId.value);
-};
+async function handleStartAnalysis() {
+	const fen = gamesStore.getCurrentPosition(activeBoardId.value)?.fen;
+	if (fen) {
+		await engineAnalysisStore.analyzePosition(selectedEngine.value, fen);
+	}
+}
 
-const navigateToEnd = async () => {
-	await globalStore.gamesStore.navigateToEnd(activeBoardId.value);
-};
-
-const navigateToPrevious = async () => {
-	await globalStore.gamesStore.previousMove(activeBoardId.value);
-};
-
-const navigateToNext = async () => {
-	await globalStore.gamesStore.nextMove(activeBoardId.value);
-};
-
-const newGameClick = async () => {
-	// TODO: Add UI for selecting variant
-
-	const boardId = uiStore.createNewBoard();
-	await globalStore.gamesStore.newGame(boardId, "standard");
-
-	console.log("New game created:", globalStore.activeGame);
-};
+async function handleStartGameAnalysis() {
+	const gameId = boardState.value?.game.id;
+	if (gameId) {
+		await engineAnalysisStore.analyzeGame(selectedEngine.value, gameId);
+	}
+}
 </script>
 
 <style>

--- a/src/components/AnnotationArrow/AnnotationArrow.story.vue
+++ b/src/components/AnnotationArrow/AnnotationArrow.story.vue
@@ -1,0 +1,88 @@
+<template>
+
+	<Story
+		title="Annotation Arrow"
+		:layout="{ type: 'grid' }"
+	>
+
+		<template #controls>
+
+			<div class="flex flex-col gap-2">
+
+				<div class="flex flex-row gap-2">
+
+					<HstNumber
+						v-model="state.startX"
+						title="Start X"
+					/>
+
+					<HstNumber
+						v-model="state.startY"
+						title="Start Y"
+					/>
+
+				</div>
+
+				<div class="flex flex-row gap-2">
+
+					<HstNumber
+						v-model="state.endX"
+						title="End X"
+					/>
+
+					<HstNumber
+						v-model="state.endY"
+						title="End Y"
+					/>
+
+				</div>
+
+				<div class="flex flex-row gap-2">
+
+					<HstSelect
+						v-model="state.color"
+						:options="usedColors"
+						title="Color"
+					/>
+
+					<HstNumber
+						v-model="state.size"
+						title="Size"
+					/>
+
+				</div>
+
+			</div>
+
+		</template>
+
+		<Variant title="Default">
+
+			<AnnotationArrow
+				:from="{ x: state.startX, y: state.startY }"
+				:to="{ x: state.endX, y: state.endY }"
+				:options="{ color: state.color, size: state.size }"
+			/>
+
+		</Variant>
+
+	</Story>
+
+</template>
+
+<script setup lang="ts">
+import { reactive } from "vue";
+import AnnotationArrow from "./AnnotationArrow.vue";
+
+const usedColors = ["blue", "green", "red", "yellow"];
+
+const state = reactive({
+	startX: 0,
+	startY: 0,
+	endX: 128,
+	endY: 128,
+	color: usedColors[0],
+	size: 5,
+});
+</script>
+

--- a/src/components/AnnotationArrow/AnnotationArrow.vue
+++ b/src/components/AnnotationArrow/AnnotationArrow.vue
@@ -5,47 +5,74 @@
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 512 512"
-			class="absolute inset-0 pointer-events-none z-10 opacity-80"
+			width="512"
+			height="512"
+			class="absolute inset-0 pointer-events-none z-10"
 		>
 
 			<defs>
 
+				<filter
+					id="arrowShadow"
+					x="-50%"
+					y="-50%"
+					width="200%"
+					height="200%"
+				>
+
+					<feDropShadow
+						dx="1"
+						dy="1"
+						stdDeviation="1.5"
+						flood-opacity="0.3"
+					/>
+
+				</filter>
+
 				<marker
-					id="arrowhead"
-					markerWidth="10"
-					markerHeight="7"
-					refX="3"
-					refY="2"
+					:id="`arrowhead-${markerId}`"
+					markerWidth="12"
+					markerHeight="10"
+					refX="6"
+					refY="5"
 					orient="auto"
 					markerUnits="strokeWidth"
 				>
 
 					<polygon
-						points="0 0, 3 2, 0 4"
+						points="0,1 8,5 0,9 2,5"
 						:fill="computedColor"
+						stroke="none"
 					/>
 
 				</marker>
 
 			</defs>
 
-			<rect
-				width="512"
-				height="512"
+			<line
+				:x1="adjustedFrom.x"
+				:y1="adjustedFrom.y"
+				:x2="adjustedTo.x"
+				:y2="adjustedTo.y"
 				fill="none"
+				stroke="rgba(0, 0, 0, 0.2)"
+				stroke-linecap="round"
+				:stroke-width="computedSize + 2"
 			/>
 
 			<line
-				:x1="from.x"
-				:y1="from.y"
-				:x2="to.x"
-				:y2="to.y"
+				:x1="adjustedFrom.x"
+				:y1="adjustedFrom.y"
+				:x2="adjustedTo.x"
+				:y2="adjustedTo.y"
 				fill="none"
 				:stroke="computedColor"
 				stroke-linecap="round"
 				stroke-linejoin="round"
 				:stroke-width="computedSize"
-				marker-end="url(#arrowhead)"
+				:marker-end="`url(#arrowhead-${markerId})`"
+				filter="url(#arrowShadow)"
+				opacity="0.9"
 			/>
 
 		</svg>
@@ -55,31 +82,75 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRefs } from "vue";
+import { computed } from "vue";
 
-const props = defineProps<{
-	to: {
-		x: number;
-		y: number;
-	};
-	from: {
-		x: number;
-		y: number;
-	};
-	options: {
-		color?: string;
-		size?: number;
-	};
-}>();
+interface ArrowOptions {
+	color?: string;
+	size?: number;
+}
 
-const { color, size } = toRefs(props.options);
+interface Position {
+	x: number;
+	y: number;
+}
 
-const computedSize = computed(() => {
-	return size?.value ?? 10;
+interface Props {
+	from: Position;
+	to: Position;
+	options?: ArrowOptions;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	options: () => ({}),
 });
 
-const computedColor = computed(() => {
-	return color?.value ?? "currentColor";
+const computedSize = computed((): number => {
+	return props.options.size ?? 8;
+});
+
+const computedColor = computed((): string => {
+	return props.options.color ?? "#fbbf24";
+});
+
+// Generate unique marker ID to avoid conflicts when multiple arrows have different colors
+const markerId = computed((): string => {
+	return computedColor.value.replace("#", "");
+});
+
+// Adjust arrow positioning to account for arrowhead size
+const adjustedFrom = computed((): Position => {
+	const dx = props.to.x - props.from.x;
+	const dy = props.to.y - props.from.y;
+	const length = Math.sqrt(dx * dx + dy * dy);
+
+	if (length === 0) return props.from;
+
+	const unitX = dx / length;
+	const unitY = dy / length;
+	const offset = computedSize.value * 0.3;
+
+	return {
+		x: props.from.x + unitX * offset,
+		y: props.from.y + unitY * offset,
+	};
+});
+
+const adjustedTo = computed((): Position => {
+	const dx = props.to.x - props.from.x;
+	const dy = props.to.y - props.from.y;
+	const length = Math.sqrt(dx * dx + dy * dy);
+
+	if (length === 0) return props.to;
+
+	const unitX = dx / length;
+	const unitY = dy / length;
+	// Increase offset to prevent line from showing through arrowhead
+	const offset = computedSize.value * 1.2;
+
+	return {
+		x: props.to.x - unitX * offset,
+		y: props.to.y - unitY * offset,
+	};
 });
 </script>
 

--- a/src/components/GameLibrary/GameLibrary.story.vue
+++ b/src/components/GameLibrary/GameLibrary.story.vue
@@ -1,0 +1,143 @@
+<template>
+
+	<Story title="Game Library">
+
+		<Variant title="Default">
+
+			<GameLibrary
+				:games="games"
+				:is-loading="isLoading"
+				:error="error"
+				@open-game="logEvent('open-game', $event)"
+				@delete-game="logEvent('delete-game', $event)"
+				@update-game-property="logEvent('update-game-property', $event)"
+				@refresh-games="logEvent('refresh-games', $event)"
+			/>
+
+		</Variant>
+
+	</Story>
+
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import GameLibrary from "./GameLibrary.vue";
+import type { ExplorerGame } from "../../shared/types";
+import { logEvent } from "histoire/client";
+
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+const games = ref<ExplorerGame[]>([
+	{
+		id: 1,
+		white_player: { id: 1, name: "Player 1", elo: 1800, country: null },
+		black_player: { id: 2, name: "Player 2", elo: 1850, country: null },
+		date: "2024.01.01",
+		result: "1-0",
+		tournament: null,
+		opening: null,
+		round: 1,
+		tags: ["favorite"],
+		headers: [],
+		move_tree: {
+			game_id: 0,
+			nodes: [],
+			root_id: undefined,
+			current_node_id: undefined,
+		},
+		fen: null,
+		variant: "standard",
+		pgn: null,
+	},
+	{
+		id: 2,
+		white_player: {
+			id: 3,
+			name: "Unknown Game Date",
+			elo: 1900,
+			country: null,
+		},
+		black_player: { id: 1, name: "Player 1", elo: 1800, country: null },
+		date: "",
+		result: "1/2-1/2",
+		tournament: null,
+		opening: null,
+		round: 2,
+		tags: [],
+		headers: [],
+		move_tree: {
+			game_id: 0,
+			nodes: [],
+			root_id: undefined,
+			current_node_id: undefined,
+		},
+		fen: null,
+		variant: "standard",
+		pgn: null,
+	},
+	{
+		id: 3,
+		white_player: {
+			id: 1,
+			name: "Slightly Longer Name",
+			elo: 1800,
+			country: null,
+		},
+		black_player: {
+			id: 2,
+			name: "Even-Slightly Longer Name",
+			elo: 1850,
+			country: null,
+		},
+		date: "2024.01.03",
+		result: "0-1",
+		tournament: null,
+		opening: null,
+		round: 3,
+		tags: [],
+		headers: [],
+		move_tree: {
+			game_id: 0,
+			nodes: [],
+			root_id: undefined,
+			current_node_id: undefined,
+		},
+		fen: null,
+		variant: "standard",
+		pgn: null,
+	},
+	{
+		id: 4,
+		white_player: {
+			id: 1,
+			name: "Player Name For An Ongoing Game",
+			elo: 1800,
+			country: null,
+		},
+		black_player: {
+			id: 2,
+			name: "Player Name For Another Ongoing Game",
+			elo: 1850,
+			country: null,
+		},
+		date: "2024.01.04",
+		result: "*",
+		tournament: null,
+		opening: null,
+		round: 4,
+		tags: [],
+		headers: [],
+		move_tree: {
+			game_id: 0,
+			nodes: [],
+			root_id: undefined,
+			current_node_id: undefined,
+		},
+		fen: null,
+		variant: "standard",
+		pgn: null,
+	},
+]);
+</script>
+

--- a/src/components/ImportModal/ImportModal.story.vue
+++ b/src/components/ImportModal/ImportModal.story.vue
@@ -1,0 +1,21 @@
+<template>
+
+	<Story title="Import Modal">
+
+		<div class="flex flex-col gap-4 w-full h-full">
+
+			<ImportModal
+				:is-open="true"
+				@close="() => {}"
+			/>
+
+		</div>
+
+	</Story>
+
+</template>
+
+<script setup lang="ts">
+import ImportModal from "./ImportModal.vue";
+</script>
+

--- a/src/components/ImportModal/ImportModal.story.vue
+++ b/src/components/ImportModal/ImportModal.story.vue
@@ -2,20 +2,37 @@
 
 	<Story title="Import Modal">
 
-		<div class="flex flex-col gap-4 w-full h-full">
-
-			<ImportModal
-				:is-open="true"
-				@close="() => {}"
+		<template #controls>
+			 Is Open:
+			<HstCheckbox
+				v-model="isOpen"
+				title="Boolean"
 			/>
 
-		</div>
+		</template>
+
+		<Variant title="Default">
+
+			<div class="flex flex-col gap-4 w-full h-full">
+
+				<ImportModal
+					:is-open="isOpen"
+					@close="logEvent('close', $event)"
+				/>
+
+			</div>
+
+		</Variant>
 
 	</Story>
 
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import ImportModal from "./ImportModal.vue";
+import { logEvent } from "histoire/client";
+
+const isOpen = ref(false);
 </script>
 

--- a/src/components/ImportModal/ImportModal.story.vue
+++ b/src/components/ImportModal/ImportModal.story.vue
@@ -13,14 +13,20 @@
 
 		<Variant title="Default">
 
-			<div class="flex flex-col gap-4 w-full h-full">
+			<button
+				class="btn btn-primary mb-4"
+				@click="isOpen = true"
+			>
+				 Open Modal
+			</button>
 
-				<ImportModal
-					:is-open="isOpen"
-					@close="logEvent('close', $event)"
-				/>
-
-			</div>
+			<ImportModal
+				:is-open="isOpen"
+				@close="
+					logEvent('close', $event);
+					isOpen = false;
+				"
+			/>
 
 		</Variant>
 

--- a/src/components/ImportModal/ImportModal.vue
+++ b/src/components/ImportModal/ImportModal.vue
@@ -136,24 +136,44 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
-import { useGlobalStore } from "../../stores";
+import { computed, inject, ref, watch } from "vue";
 import Modal from "../Layout/Modal/Modal.vue";
-import { validatePGNFormat } from "../../services/ImportExportService";
+import {
+	GlobalStoreKey,
+	ImportExportServiceKey,
+	type IGlobalStore,
+	type IImportExportService,
+} from "../../composables/useInjection";
 
 const props = defineProps<{
 	isOpen: boolean;
 	onClose: () => void;
 }>();
 
-const globalStore = useGlobalStore();
+// Inject dependencies instead of importing them directly
+const globalStore = inject(GlobalStoreKey) as IGlobalStore;
+const importExportService = inject(
+	ImportExportServiceKey,
+) as IImportExportService;
+
+// Fallback error handling if dependencies aren't provided
+if (!globalStore) {
+	throw new Error(
+		"GlobalStore not provided. Make sure to call useProviders() in your app setup.",
+	);
+}
+if (!importExportService) {
+	throw new Error(
+		"ImportExportService not provided. Make sure to call useProviders() in your app setup.",
+	);
+}
 
 const loading = ref(false);
 
 const inputType = ref<"file" | "raw">("file");
 const pgn = ref<string>("");
 const pgnValid = computed(() => {
-	return validatePGNFormat(pgn.value).isValid;
+	return importExportService.validatePGNFormat(pgn.value).isValid;
 });
 
 const pgnTextarea = ref<HTMLTextAreaElement | null>(null);

--- a/src/components/Layout/StackedPanel/StackedSection.vue
+++ b/src/components/Layout/StackedPanel/StackedSection.vue
@@ -218,7 +218,8 @@ const toggleCollapse = () => {
 const onEnter = (el: Element) => {
 	const element = el as HTMLElement;
 	element.style.height = "0";
-	element.offsetHeight; // Force reflow
+	// element.offsetHeight; // Force reflow
+	element.style.height = "auto";
 	element.style.height = `${element.scrollHeight}px`;
 };
 
@@ -230,7 +231,8 @@ const onAfterEnter = (el: Element) => {
 const onLeave = (el: Element) => {
 	const element = el as HTMLElement;
 	element.style.height = `${element.scrollHeight}px`;
-	element.offsetHeight; // Force reflow
+	// element.offsetHeight; // Force reflow
+	element.style.height = "auto";
 	element.style.height = "0";
 };
 

--- a/src/components/MoveDisplay/MoveInfo/MoveInfo.story.vue
+++ b/src/components/MoveDisplay/MoveInfo/MoveInfo.story.vue
@@ -1,0 +1,109 @@
+<template>
+
+	<Story title="Move Display/Move Info">
+
+		<template #controls>
+
+			<div class="flex flex-row gap-2">
+
+				<HstButton
+					color="primary"
+					class="htw-p-2"
+					@click="addAnnotation"
+				>
+					 Add Annotation
+				</HstButton>
+
+				<HstButton
+					class="htw-p-2"
+					@click="removeAnnotation"
+				>
+					 Remove Annotation
+				</HstButton>
+
+			</div>
+
+			<HstTextarea
+				v-model="currentNode.game_move.annotations[0].comment"
+				title="Comment"
+			/>
+
+		</template>
+
+		<Variant title="Default">
+
+			<MoveInfo
+				:current-node="currentNode"
+				@update-move-comment="
+					logEvent('update-move-comment', {
+						comment: $event,
+					})
+				"
+			/>
+
+		</Variant>
+
+	</Story>
+
+</template>
+
+<script setup lang="ts">
+import { reactive } from "vue";
+import MoveInfo from "./MoveInfo.vue";
+import { logEvent } from "histoire/client";
+
+const currentNode = reactive({
+	position: {
+		id: 0,
+		fen: "",
+		evaluations: [
+			{
+				score: 123,
+				eval_type: "cp",
+				depth: 99,
+				engine: "Stockfish",
+			},
+		],
+		variant: null,
+	},
+	game_move: {
+		id: 0,
+		game_id: 0,
+		ply_number: 1,
+		san: "e4",
+		uci: "e2e4",
+		position: null,
+		annotations: [
+			{
+				id: 0,
+				comment: "A text annotation for the move",
+				arrows: null,
+				highlights: null,
+			},
+		],
+		time_info: {
+			time_spent_ms: 123456,
+			time_left_ms: 789012,
+		},
+		parent_move_id: null,
+	},
+	parent_id: null,
+	children_ids: [],
+});
+
+const addAnnotation = () => {
+	currentNode.game_move.annotations.push({
+		id: currentNode.game_move.annotations.length + 1,
+		comment: "A new annotation",
+		arrows: null,
+		highlights: null,
+	});
+};
+
+const removeAnnotation = () => {
+	if (currentNode.game_move.annotations.length > 0) {
+		currentNode.game_move.annotations.pop();
+	}
+};
+</script>
+

--- a/src/components/MoveDisplay/MoveInfo/MoveInfo.vue
+++ b/src/components/MoveDisplay/MoveInfo/MoveInfo.vue
@@ -45,15 +45,6 @@
 
 		</div>
 
-		<div
-			v-else
-			class="flex items-center gap-2 text-sm"
-		>
-
-			<span class="text-base-content/60">No evaluation</span>
-
-		</div>
-
 		<!-- Time info -->
 
 		<div
@@ -74,21 +65,9 @@
 
 		</div>
 
-		<div
-			v-else
-			class="flex items-center gap-2 text-sm"
-		>
-
-			<span class="text-base-content/60">No time info</span>
-
-		</div>
-
 		<!-- Annotations -->
 
-		<div
-			v-if="currentAnnotations.length > 0"
-			class="space-y-2"
-		>
+		<div class="space-y-2">
 
 			<div
 				v-for="annotation in currentAnnotations"
@@ -131,15 +110,6 @@
 
 		</div>
 
-		<div
-			v-else
-			class="flex items-center gap-2 text-sm"
-		>
-
-			<span class="text-base-content/60">No annotations</span>
-
-		</div>
-
 	</div>
 
 </template>
@@ -169,6 +139,10 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+
+const emit = defineEmits<{
+	(e: "update-move-comment", value: string): void;
+}>();
 
 const { formatEvaluation, formatTime } = useFormatting();
 
@@ -255,7 +229,19 @@ const currentAnnotations = computed((): ChessAnnotation[] => {
 
 const handleCommentInput = (event: Event) => {
 	const textarea = event.target as HTMLTextAreaElement;
-	textarea.value = textarea.value.replace(/[^a-zA-Z0-9\s]/g, "");
+	// TODO: Tweak the regex to allow more characters
+	// eventually we want to extract any references to squares, moves, etc.
+	// and replace them with interactive elements (e.g. hovering over a square
+	// should temporarily highlight the square on the board)
+	const comment = textarea.value.replace(/[^a-zA-Z0-9.,!?\s]/g, "");
+	emit("update-move-comment", comment);
+
+	// FIXME: The parent component should handle the update of the comment
+	// in the currentNode which is then passed back to the MoveInfo component
+	// to update the comment in the currentNode.
+	// However, this isn't implemented yet, so we need to update the
+	// element's comment/value directly.
+	textarea.value = comment;
 };
 </script>
 

--- a/src/composables/useInjection.ts
+++ b/src/composables/useInjection.ts
@@ -1,28 +1,145 @@
 import type { InjectionKey } from "vue";
-import type { OperationResult } from "../shared/types";
+import type {
+	ActiveGameState,
+	AlertToast,
+	ExplorerGame,
+	FilterOption,
+	OperationResult,
+	SortOption,
+} from "../shared/types";
+import {
+	UITheme,
+	LightUITheme,
+	DarkUITheme,
+	BoardTheme,
+} from "../shared/themes";
 
 // Define interfaces for the services we want to inject
 export interface IGlobalStore {
 	importPGNGames(pgn: string): Promise<void>;
-	// Add other global store methods as needed
+	updateGameProperty(
+		gameId: number,
+		property: string,
+		value: string,
+	): Promise<void>;
+	fetchExplorerGames(): Promise<ExplorerGame[]>;
+	explorerGames: ExplorerGame[];
+}
+
+// UiStoreKey
+export interface IUiStore {
+	addAlert(alert: Omit<AlertToast, "key"> & { key?: string }): void;
+	createNewBoard(): number;
+
+	activeBoardId: number;
+	visibleGameHeaders: string[];
+	theme: UITheme;
+	defaultLightTheme: LightUITheme;
+	defaultDarkTheme: DarkUITheme;
+	boardTheme: BoardTheme;
+}
+
+// GamesStoreKey
+export interface IGamesStore {
+	activeGameMap: Map<number, ActiveGameState>;
+	openGame(gameId: number, boardId: number): Promise<ActiveGameState | null>;
+	deleteGame(gameId: number): Promise<boolean>;
 }
 
 export interface IImportExportService {
 	validatePGNFormat(pgn: string): { isValid: boolean; error?: string };
 	importPGNGames(pgn: string): Promise<OperationResult>;
-	// Add other service methods as needed
+	fetchExplorerGames(): Promise<ExplorerGame[]>;
+	searchGames(games: ExplorerGame[], query: string): ExplorerGame[];
+	filterGames(
+		games: ExplorerGame[],
+		filter: FilterOption,
+		filterTags: string[],
+	): ExplorerGame[];
+	sortGames(
+		games: ExplorerGame[],
+		sortType: SortOption,
+		sortOrder: "asc" | "desc",
+	): ExplorerGame[];
 }
 
 // Define injection keys with proper typing
 export const GlobalStoreKey: InjectionKey<IGlobalStore> = Symbol("GlobalStore");
 export const ImportExportServiceKey: InjectionKey<IImportExportService> =
 	Symbol("ImportExportService");
+export const UiStoreKey: InjectionKey<IUiStore> = Symbol("UiStore");
+export const GamesStoreKey: InjectionKey<IGamesStore> = Symbol("GamesStore");
 
 // Helper function to create a mock implementation
 export const createMockGlobalStore = (): IGlobalStore => ({
 	importPGNGames: async (pgn: string) => {
 		console.log("Mock: Would import PGN:", pgn);
 		await new Promise((resolve) => setTimeout(resolve, 1000));
+	},
+	updateGameProperty: async (
+		gameId: number,
+		property: string,
+		value: string,
+	) => {
+		console.log("Mock: Would update game property:", gameId, property, value);
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	},
+	explorerGames: [
+		{
+			id: 1,
+			white_player: {
+				id: 1,
+				name: "Player 1",
+				elo: 1000,
+				country: "USA",
+			},
+			black_player: {
+				id: 2,
+				name: "Player 2",
+				elo: 1000,
+				country: "USA",
+			},
+			tournament: {
+				id: 1,
+				name: "Tournament 1",
+				tournament_type: "Round Robin",
+				time_control: "10+0",
+				start_date: "2021-01-01",
+				end_date: "2021-01-01",
+				location: "USA",
+			},
+			opening: {
+				id: 1,
+				name: "Opening 1",
+				eco: "A00",
+				variation:
+					"1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. b4 Bxb4 5. c3 Ba5 6. d4 exd4 7. O-O d3 8. Qb3 Qb6 9. Rfe1 Qxb2 10. Nbd2 Qc3 11. Nf1 Qd2 12. Nc1 Qc3 13. Nb3 Qb2",
+			},
+			result: "1-0",
+			fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			variant: "standard",
+			pgn: "1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. b4 Bxb4 5. c3 Ba5 6. d4 exd4 7. O-O d3 8. Qb3 Qb6 9. Rfe1 Qxb2 10. Nbd2 Qc3 11. Nf1 Qd2 12. Nc1 Qc3 13. Nb3 Qb2",
+			tags: ["A test tag", "Another test tag"],
+			round: 1,
+			date: "2021-01-01",
+			headers: [
+				{
+					id: 1,
+					game_id: 1,
+					name: "Event",
+					value: "Tournament 1",
+				},
+			],
+			move_tree: {
+				game_id: 1,
+				nodes: [],
+			},
+		},
+	],
+	fetchExplorerGames: async () => {
+		console.log("Mock: Would fetch explorer games");
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		return [];
 	},
 });
 
@@ -61,5 +178,31 @@ export const createMockImportExportService = (): IImportExportService => ({
 		console.log("Mock service: Would import PGN:", pgn);
 		await new Promise((resolve) => setTimeout(resolve, 500));
 		return { success: true, data: undefined, error: undefined };
+	},
+	fetchExplorerGames: async () => {
+		console.log("Mock: Would fetch explorer games");
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		return createMockGlobalStore().explorerGames;
+	},
+
+	searchGames: (games: ExplorerGame[], query: string) => {
+		console.log("Mock: Would search games:", query);
+		return games;
+	},
+	filterGames: (
+		games: ExplorerGame[],
+		filter: FilterOption,
+		filterTags: string[],
+	) => {
+		console.log("Mock: Would filter games:", filter, filterTags);
+		return games;
+	},
+	sortGames: (
+		games: ExplorerGame[],
+		sortType: SortOption,
+		sortOrder: "asc" | "desc" = "desc",
+	) => {
+		console.log("Mock: Would sort games:", sortType, sortOrder);
+		return games;
 	},
 });

--- a/src/composables/useInjection.ts
+++ b/src/composables/useInjection.ts
@@ -1,0 +1,65 @@
+import type { InjectionKey } from "vue";
+import type { OperationResult } from "../shared/types";
+
+// Define interfaces for the services we want to inject
+export interface IGlobalStore {
+	importPGNGames(pgn: string): Promise<void>;
+	// Add other global store methods as needed
+}
+
+export interface IImportExportService {
+	validatePGNFormat(pgn: string): { isValid: boolean; error?: string };
+	importPGNGames(pgn: string): Promise<OperationResult>;
+	// Add other service methods as needed
+}
+
+// Define injection keys with proper typing
+export const GlobalStoreKey: InjectionKey<IGlobalStore> = Symbol("GlobalStore");
+export const ImportExportServiceKey: InjectionKey<IImportExportService> =
+	Symbol("ImportExportService");
+
+// Helper function to create a mock implementation
+export const createMockGlobalStore = (): IGlobalStore => ({
+	importPGNGames: async (pgn: string) => {
+		console.log("Mock: Would import PGN:", pgn);
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	},
+});
+
+export const createMockImportExportService = (): IImportExportService => ({
+	validatePGNFormat: (pgn: string) => {
+		if (!pgn || pgn.trim().length === 0) {
+			return { isValid: false, error: "PGN content is empty" };
+		}
+
+		// Basic checks for PGN format
+		const lines = pgn.split("\n");
+		let hasGameMoves = false;
+		let hasHeaders = false;
+
+		for (const line of lines) {
+			const trimmedLine = line.trim();
+
+			// Check for PGN headers
+			if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")) {
+				hasHeaders = true;
+			}
+
+			// Check for move notation (simplified check)
+			if (trimmedLine.match(/^\d+\.?\s+[a-zA-Z]/)) {
+				hasGameMoves = true;
+			}
+		}
+
+		if (!hasHeaders && !hasGameMoves) {
+			return { isValid: false, error: "No valid PGN headers or moves found" };
+		}
+
+		return { isValid: true };
+	},
+	importPGNGames: async (pgn: string) => {
+		console.log("Mock service: Would import PGN:", pgn);
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		return { success: true, data: undefined, error: undefined };
+	},
+});

--- a/src/composables/useProviders.ts
+++ b/src/composables/useProviders.ts
@@ -1,0 +1,111 @@
+import { App, provide } from "vue";
+import {
+	GlobalStoreKey,
+	ImportExportServiceKey,
+	type IGlobalStore,
+	type IImportExportService,
+} from "./useInjection";
+
+/**
+ * Provides the real implementations of stores and services
+ * Call this in your main app setup
+ */
+export const useProviders = async () => {
+	// Dynamically import to avoid loading issues in test environments
+	const { useGlobalStore } = await import("../stores");
+	const ImportExportService = await import("../services/ImportExportService");
+
+	const globalStore = useGlobalStore();
+
+	// Provide the real global store
+	const globalStoreImpl: IGlobalStore = {
+		importPGNGames: (pgn: string) => globalStore.importPGNGames(pgn),
+		// Add other methods as needed
+	};
+
+	// Provide the real import/export service
+	const importExportServiceImpl: IImportExportService = {
+		validatePGNFormat: ImportExportService.validatePGNFormat,
+		importPGNGames: ImportExportService.importPGNGames,
+		// Add other methods as needed
+	};
+
+	provide(GlobalStoreKey, globalStoreImpl);
+	provide(ImportExportServiceKey, importExportServiceImpl);
+};
+
+/**
+ * Provides real implementations using app.provide
+ * Call this in your main app setup with the app instance
+ */
+export const useAppProviders = async (app: App) => {
+	// Dynamically import to avoid loading issues in test environments
+	const { useGlobalStore } = await import("../stores");
+	const ImportExportService = await import("../services/ImportExportService");
+
+	const globalStore = useGlobalStore();
+
+	// Provide the real global store
+	const globalStoreImpl: IGlobalStore = {
+		importPGNGames: (pgn: string) => globalStore.importPGNGames(pgn),
+	};
+
+	// Provide the real import/export service
+	const importExportServiceImpl: IImportExportService = {
+		validatePGNFormat: ImportExportService.validatePGNFormat,
+		importPGNGames: ImportExportService.importPGNGames,
+	};
+
+	app.provide(GlobalStoreKey, globalStoreImpl);
+	app.provide(ImportExportServiceKey, importExportServiceImpl);
+};
+
+/**
+ * Provides mock implementations for testing/stories
+ * Call this in your test setup or Histoire setup
+ */
+export const useMockProviders = () => {
+	const mockGlobalStore: IGlobalStore = {
+		importPGNGames: async (pgn: string) => {
+			console.log("Mock: Would import PGN:", pgn);
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		},
+	};
+
+	const mockImportExportService: IImportExportService = {
+		validatePGNFormat: (pgn: string) => {
+			if (!pgn || pgn.trim().length === 0) {
+				return { isValid: false, error: "PGN content is empty" };
+			}
+
+			// Basic PGN validation
+			const lines = pgn.split("\n");
+			let hasGameMoves = false;
+			let hasHeaders = false;
+
+			for (const line of lines) {
+				const trimmedLine = line.trim();
+				if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")) {
+					hasHeaders = true;
+				}
+				if (trimmedLine.match(/^\d+\.?\s+[a-zA-Z]/)) {
+					hasGameMoves = true;
+				}
+			}
+
+			if (!hasHeaders && !hasGameMoves) {
+				return { isValid: false, error: "No valid PGN headers or moves found" };
+			}
+
+			return { isValid: true };
+		},
+		importPGNGames: async (pgn: string) => {
+			console.log("Mock service: Would import PGN:", pgn);
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			return { success: true, data: undefined, error: undefined };
+		},
+	};
+
+	provide(GlobalStoreKey, mockGlobalStore);
+	provide(ImportExportServiceKey, mockImportExportService);
+};

--- a/src/histoire.setup.ts
+++ b/src/histoire.setup.ts
@@ -7,15 +7,19 @@ import {
 	createMockImportExportService,
 } from "./composables/useInjection";
 
+import ComponentWrapper from "./histoire/ComponentWrapper.vue";
+
 import "./style.css";
 
-export const setupVue3 = defineSetupVue3(({ app }) => {
+export const setupVue3 = defineSetupVue3(({ app, addWrapper }) => {
 	const pinia = createPinia();
 	app.use(pinia);
 
 	// Provide mock implementations for all stories using app.provide
 	app.provide(GlobalStoreKey, createMockGlobalStore());
 	app.provide(ImportExportServiceKey, createMockImportExportService());
+
+	addWrapper(ComponentWrapper);
 
 	console.log("Histoire setup complete with mock providers");
 });

--- a/src/histoire.setup.ts
+++ b/src/histoire.setup.ts
@@ -1,0 +1,67 @@
+import { defineSetupVue3 } from "@histoire/plugin-vue";
+import { createPinia } from "pinia";
+import { ErrorHandler, ErrorSeverity } from "./services/ErrorService";
+import { useGlobalStore } from "./stores";
+import { useSettingsStore } from "./stores/settings";
+
+import "./style.css";
+
+export const setupVue3 = defineSetupVue3(({ app }) => {
+	const pinia = createPinia();
+	app.use(pinia);
+
+	// Temporarily fake window.matchMedia("(prefers-color-scheme: dark)").matches
+	// while the UI store is initialized
+	const originalMatchMedia = window.matchMedia;
+	window.matchMedia = (query) => {
+		return {
+			matches: false,
+			media: query,
+		} as MediaQueryList;
+	};
+	// Setup hotkeys after app is mounted to ensure stores are ready
+	const settingsStore = useSettingsStore();
+	const globalStore = useGlobalStore();
+
+	window.matchMedia = originalMatchMedia; // Restore original matchMedia
+
+	// Initialize error service after stores are ready
+	// Set up error listener to show alerts to users
+	ErrorHandler.addListener((error) => {
+		// Map error severity to alert type
+		let alertType: "error" | "warning" | "info" = "error";
+		if (error.severity === ErrorSeverity.LOW) {
+			alertType = "info";
+		} else if (error.severity === ErrorSeverity.MEDIUM) {
+			alertType = "warning";
+		}
+
+		// Show user-friendly alert
+		globalStore.uiStore.addAlert({
+			key: `error-${Date.now()}`, // Unique key based on timestamp
+			type: alertType,
+			title: error.category
+				.replace(/_/g, " ")
+				.toLowerCase()
+				.replace(/\b\w/g, (l) => l.toUpperCase()),
+			message: error.message,
+			timeout: error.severity === ErrorSeverity.LOW ? 3000 : 5000,
+		});
+	});
+
+	// Initialize hotkeys with default callbacks
+	// These are the callbacks that will be used no matter the hotkey configuration
+	settingsStore.initializeHotkeys({
+		next_move: () =>
+			globalStore.gamesStore.nextMove(globalStore.uiStore.activeBoardId),
+		prev_move: () =>
+			globalStore.gamesStore.previousMove(globalStore.uiStore.activeBoardId),
+		goto_start: () =>
+			globalStore.gamesStore.navigateToStart(globalStore.uiStore.activeBoardId),
+		goto_end: () =>
+			globalStore.gamesStore.navigateToEnd(globalStore.uiStore.activeBoardId),
+		toggle_left_panel: () => globalStore.uiStore.toggleLeftPanel(),
+		toggle_right_panel: () => globalStore.uiStore.toggleRightPanel(),
+		open_settings: () => globalStore.uiStore.updateSettingsModalOpen(true),
+	});
+});

--- a/src/histoire/ComponentWrapper.vue
+++ b/src/histoire/ComponentWrapper.vue
@@ -1,0 +1,21 @@
+<script lang="ts" setup>
+import { Story, Variant } from "histoire";
+
+defineProps<{
+	story: Story;
+	variant?: Variant;
+}>();
+</script>
+
+<template>
+
+	<div
+		class="p-4 border border-base-300 rounded-md min-h-[200px] min-w-[200px] w-full h-full"
+	>
+
+		<slot />
+
+	</div>
+
+</template>
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import App from "./App.vue";
 import { ErrorHandler, ErrorSeverity } from "./services/ErrorService";
 import { useGlobalStore } from "./stores";
 import { useSettingsStore } from "./stores/settings";
+import { useAppProviders } from "./composables/useProviders";
 import {
 	warn,
 	debug,
@@ -53,12 +54,15 @@ const pinia = createPinia();
 
 app.use(pinia);
 
-// Initialize the app
-app.mount("#app");
-
-// Setup hotkeys after app is mounted to ensure stores are ready
+// Setup stores and dependency injection before mounting
 const settingsStore = useSettingsStore();
 const globalStore = useGlobalStore();
+
+// Provide real implementations for dependency injection
+await useAppProviders(app);
+
+// Initialize the app
+app.mount("#app");
 
 // Initialize error service after stores are ready
 // Set up error listener to show alerts to users

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,6 +15,20 @@ import type {
 // generally types/constants could use some better organization
 // but that's a 'todo' for another day
 
+export interface ActiveGameState {
+	id: number;
+	game: ChessGame;
+
+	// UI state
+	hideEvaluationBar: boolean;
+	hideBestMove: boolean;
+	hideThreats: boolean;
+
+	// Loading states
+	isLoading: boolean;
+	error: string | null;
+}
+
 export interface NodeId {
 	idx: number;
 	version: number;

--- a/src/stores/engineAnalysis.ts
+++ b/src/stores/engineAnalysis.ts
@@ -29,6 +29,9 @@ export const useEngineAnalysisStore = defineStore("engineAnalysis", {
 			if (!engine) return undefined;
 			return EngineService.getLatestBestMove(engine);
 		},
+		isAnalyzing: (state) => (engineName: string) => {
+			return state.engines.get(engineName)?.isAnalyzing ?? false;
+		},
 		boardEvaluation: (state): Score => {
 			return EngineService.calculateBoardEvaluation(state.engines);
 		},

--- a/src/stores/games.ts
+++ b/src/stores/games.ts
@@ -19,21 +19,7 @@ import {
 	refreshGameState,
 	saveGameSession,
 } from "../services/GameService";
-import type { ChessGame } from "../shared/bindings";
-
-interface ActiveGameState {
-	id: number;
-	game: ChessGame;
-
-	// UI state
-	hideEvaluationBar: boolean;
-	hideBestMove: boolean;
-	hideThreats: boolean;
-
-	// Loading states
-	isLoading: boolean;
-	error: string | null;
-}
+import type { ActiveGameState } from "../shared/types";
 
 /**
  * A store for managing the states of ALL open games using session-focused API

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -141,9 +141,12 @@ export const useSettingsStore = defineStore("settings", {
 
 		saveHotkeys() {
 			// Save hotkey configuration without the callbacks
-			const hotkeyConfig = this.hotkeys.map(
-				({ callback, ...config }) => config,
-			);
+			const hotkeyConfig = this.hotkeys.map(({ ...config }) => {
+				return {
+					...config,
+					callback: undefined,
+				};
+			});
 			localStorage.setItem("hotkeys", JSON.stringify(hotkeyConfig));
 		},
 

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -62,11 +62,13 @@ export const useUIStore = defineStore("ui", {
 		defaultDarkTheme: (localStorage.getItem(defaultDarkThemeKey) ??
 			"dark") as DarkUITheme,
 		boardTheme: getDefaultBoardTheme(),
+		showCoordinates: true,
+		showLegalMoves: true,
 
 		boardSquareSize: 64,
 		_whiteOnSide: "top" as "top" | "bottom",
 
-		// Enhanced layout state
+		// Layout state
 		layout: {
 			leftPanelWidth: 300,
 			rightPanelWidth: 250,
@@ -127,6 +129,8 @@ export const useUIStore = defineStore("ui", {
 		getTheme: (state) => state.theme,
 		isDarkMode: (state) => darkUIThemes.includes(state.theme as DarkUITheme),
 		getBoardTheme: (state) => state.boardTheme,
+		getShowCoordinates: (state) => state.showCoordinates,
+		getShowLegalMoves: (state) => state.showLegalMoves,
 		getBoardSquareSize: (state) => state.boardSquareSize,
 		whiteOnSide: (state) => state._whiteOnSide,
 
@@ -220,6 +224,14 @@ export const useUIStore = defineStore("ui", {
 
 		updateBoardTheme(theme: BoardTheme) {
 			this.boardTheme = theme;
+		},
+
+		updateShowCoordinates(show: boolean) {
+			this.showCoordinates = show;
+		},
+
+		updateShowLegalMoves(show: boolean) {
+			this.showLegalMoves = show;
 		},
 
 		updateBoardSquareSize(size: number) {

--- a/src/style.css
+++ b/src/style.css
@@ -1,24 +1,5 @@
 @import "tailwindcss";
 
 @plugin "daisyui" {
-	/* biome-ignore lint/correctness/noUnknownProperty: daisyui plugin */
 	themes: all;
-}
-
-/*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
-@layer base {
-	*,
-	::after,
-	::before,
-	::backdrop,
-	::file-selector-button {
-		border-color: var(--color-gray-200, currentcolor);
-	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,22 +2,35 @@ import UnpluginTypia from "@ryoppippi/unplugin-typia/vite";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 
+const dev = process.env.NODE_ENV === "development";
 const host = process.env.TAURI_DEV_HOST;
-const isHistoire = process.env.HISTOIRE;
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-	plugins: [vue(), UnpluginTypia({})],
+export default defineConfig(() => ({
+	plugins: [
+		vue(),
+		UnpluginTypia({
+			cache: true,
+		}),
+	],
 
 	assetsInclude: ["**/*.pgn"],
+
+	esbuild: {
+		logOverride: {
+			// Typia logs a lot of warning for a number of the json validators it generates.
+			// This is a workaround to silence them.
+			"suspicious-logical-operator": "silent" as const,
+		},
+	},
 
 	// Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
 	//
 	// 1. prevent vite from obscuring rust errors
-	clearScreen: isHistoire ? true : false,
+	clearScreen: false,
 	// 2. tauri expects a fixed port, fail if that port is not available
 	server: {
-		port: isHistoire ? 6006 : 1420,
+		port: 1420,
 		strictPort: true,
 		host: host || false,
 		hmr: host

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@ import UnpluginTypia from "@ryoppippi/unplugin-typia/vite";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+const isHistoire = process.env.HISTOIRE;
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -14,10 +14,10 @@ export default defineConfig(async () => ({
 	// Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
 	//
 	// 1. prevent vite from obscuring rust errors
-	clearScreen: false,
+	clearScreen: isHistoire ? true : false,
 	// 2. tauri expects a fixed port, fail if that port is not available
 	server: {
-		port: 1420,
+		port: isHistoire ? 6006 : 1420,
 		strictPort: true,
 		host: host || false,
 		hmr: host


### PR DESCRIPTION
Adds Histoire (a storybook alternative) to the project, aiming to simplify UI development and testing by enabling more isolated testing and development of UI components.

Only a few stories have been added so far. The main obstacle is caused by the `typia` generated JSON parsing/validation functions. To summarize (for future me), the UI components rely heavily on direct communication with the stores. Alone, that wouldn't be a big deal, but the store's access to the API module is. The API module utilizes the `typia` parsing and validation functions when interacting with the backend. Even when the UI component isn't calling any store methods that use the API module or `typia` functions, an error is thrown at import (the imported file is missing exports). I tried using Histoire's inline dependency configuration option as well as removing the `UnpluginTypia` Vite plugin altogether, but neither fixed the issue. I left the force optimization of `typia` for Histoire, as it's a step in the right direction (just not the complete solution).

To work around this, I've been converting components to use the classic "Props down, events up" pattern and using provide/inject to supply stores (or mocked stores) to UI components.